### PR TITLE
Fix icon scaling on mobile

### DIFF
--- a/src/routes/user/[user]/+page.svelte
+++ b/src/routes/user/[user]/+page.svelte
@@ -87,11 +87,13 @@
     }
 
     .card .icon .user-icon {
-        height: 4rem;
+        height: auto;
+        width: 4rem;
         border-radius: 50%;
     }
 
     .card .content {
+        flex: 1;
         align-self: center;
     }
 


### PR DESCRIPTION
The icon on the user page got noticeably squashed on mobile. This pr ensures that the text will shrink before the user icon does. And when the user icon does have to shrink (extreme cases only), it'll do so whilst maintaining aspect ratio.
![image](https://github.com/user-attachments/assets/e67c09b2-39be-4ca2-ae30-bb84ba1bf9d2)
![image](https://github.com/user-attachments/assets/ea882a89-db7f-4118-93e3-f8dd50cfbad4)
