### PR TITLE
Move event schedule below information, and add how-to-attend teaser

### DIFF
--- a/components/MarkdownBlocks.tsx
+++ b/components/MarkdownBlocks.tsx
@@ -15,7 +15,7 @@ export function MarkdownBlocks(props: MarkdownBlocksProps) {
   props = { ...defaultProps, ...props };
   const blocks = props.content.split(blockSeperator);
   return (
-    <div class="flex flex-col gap-4 mb-16">
+    <div class="flex flex-col gap-4">
       {blocks.map((block) =>
         block.startsWith("# ")
           ? (

--- a/routes/[event].tsx
+++ b/routes/[event].tsx
@@ -99,8 +99,8 @@ export default async function Event(_req: Request, ctx: RouteContext) {
           )}
       </div>
       
-      {schedule && schedule.length > 0 ? <Schedule schedule={schedule} users={users}></Schedule> : null}
       <MarkdownBlocks content={content} />
+      {schedule && schedule.length > 0 ? <Schedule schedule={schedule} users={users}></Schedule> : null}
     </div>
   );
 }

--- a/static/assets/pages/event/bc25.md
+++ b/static/assets/pages/event/bc25.md
@@ -8,6 +8,14 @@ Once open, visitors can explore the world with friends, try out mods, attend int
 
 ---
 
+## How to Attend
+
+BlanketCon '25 takes place entirely within Minecraft. We're not open yet, but when the modpack is ready you'll be able to download it [on Modrinth](https://modrinth.com/organization/modfest/modpacks).
+
+Then, all you need to do is click "Connect" in the main menu!
+
+---
+
 ## Event Details
 
 |                      |                                                                       |
@@ -20,9 +28,8 @@ Once open, visitors can explore the world with friends, try out mods, attend int
 | Closing Ceremony     | Monday, Apr 28th, 2025 @ 00:00GMT                                     |
 | Who Can Participate? | **Modding project authors,<br/>aspiring talk/panel hosts, and more!** |
 | Who Can Attend?      | **Everyone!**                                                         |
-|                      |                                                                       |
 
-**Read our [BlanketCon Participation Guide](/pages/bcguide) for more info on what you can submit and what to expect.**
+Modders: **read our [BlanketCon Participation Guide](/pages/bcguide) for more info on what you can submit and what to expect.**
 
 ---
 


### PR DESCRIPTION
I've seen a few people get confused by the website layout.

* Move the event schedule below the markdownblocks.
  * should help people understand what the event *is*, since that information is now above the fold
* Add a small "how to attend" blurb that just says "download the modpack and hit connect"
  * So people know what to expect. I've seen a few people go "seems cool, not sure how i'd join though"
* Clarify that the participation guide is for modders.
* Remove a spare row in the "event details" table

![image](https://github.com/user-attachments/assets/ff8a2e73-b0e2-421a-a97d-8f252dcab672)
