### PR TITLE
Display event times in the user's current timezone

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -11,7 +11,7 @@ import * as $index from "./routes/index.tsx";
 import * as $pages_page_ from "./routes/pages/[page].tsx";
 import * as $user_user_ from "./routes/user/[user].tsx";
 import * as $vanity_bc25 from "./routes/vanity/bc25.tsx";
-
+import * as $DateTime from "./islands/DateTime.tsx";
 import type { Manifest } from "$fresh/server.ts";
 
 const manifest = {
@@ -26,7 +26,9 @@ const manifest = {
     "./routes/user/[user].tsx": $user_user_,
     "./routes/vanity/bc25.tsx": $vanity_bc25,
   },
-  islands: {},
+  islands: {
+    "./islands/DateTime.tsx": $DateTime,
+  },
   baseUrl: import.meta.url,
 } satisfies Manifest;
 

--- a/islands/DateTime.tsx
+++ b/islands/DateTime.tsx
@@ -1,5 +1,10 @@
-const FORMAT = new Intl.DateTimeFormat("en-GB", {
-    timeZone: "UTC",
+import { IS_BROWSER } from "$fresh/runtime.ts";
+
+const LOCALE = IS_BROWSER ? undefined : "en-GB";
+const TIME_ZONE = IS_BROWSER ? undefined : "UTC";
+
+const FORMAT = new Intl.DateTimeFormat(LOCALE, {
+    timeZone: TIME_ZONE,
     timeZoneName: "short",
     day: "numeric",
     month: "short",
@@ -7,8 +12,9 @@ const FORMAT = new Intl.DateTimeFormat("en-GB", {
     hour: "numeric",
     minute: "2-digit"
 })
-const FORMAT_TIMEONLY = new Intl.DateTimeFormat("en-GB", {
-    timeZone: "UTC",
+
+const FORMAT_TIMEONLY = new Intl.DateTimeFormat(LOCALE, {
+    timeZone: TIME_ZONE,
     timeZoneName: "short",
     hour: "numeric",
     minute: "2-digit"
@@ -19,5 +25,5 @@ export default function FormattedDateTime(props: {time: string, timeOnly?: boole
         {
             (props.timeOnly ? FORMAT_TIMEONLY : FORMAT).format(new Date(props.time))
         }
-    </time>
+    </time> 
 }

--- a/islands/DateTime.tsx
+++ b/islands/DateTime.tsx
@@ -25,5 +25,5 @@ export default function FormattedDateTime(props: {time: string, timeOnly?: boole
         {
             (props.timeOnly ? FORMAT_TIMEONLY : FORMAT).format(new Date(props.time))
         }
-    </time> 
+    </time>
 }

--- a/routes/[event].tsx
+++ b/routes/[event].tsx
@@ -5,7 +5,7 @@ import { getPagesMarkdown } from "../lib/helpers.tsx";
 import { MarkdownBlocks } from "../components/MarkdownBlocks.tsx";
 import { ScheduleEntryData, User } from "../lib/types.d.tsx";
 import UserLink from "../components/UserLink.tsx";
-import FormattedDateTime from "../components/DateTime.tsx";
+import FormattedDateTime from "../islands/DateTime.tsx";
 
 export default async function Event(_req: Request, ctx: RouteContext) {
   const event = await fetchEvent(fetch, ctx.params.event);


### PR DESCRIPTION
Change `<FormattedDateTime>` to a [Fresh interactive island](https://fresh.deno.dev/docs/concepts/islands). When the island hydrates on the client, it re-formats the datetime in the user's current locale and timezone. If JS is disabled, the datetime is visible in UTC with `en-GB`-style fomatting just like before.

TODO: doesn't work on the "Event Details" table; I guess you can't stick components inside markdownblocks, and I don't know enough about Fresh to fix it. But the events table is the most important part ^^

![image](https://github.com/user-attachments/assets/e771d3d7-1868-4648-836f-c228d2f7b0b4)
